### PR TITLE
Implement list_webhooks wrapper

### DIFF
--- a/openphone_sdk/__init__.py
+++ b/openphone_sdk/__init__.py
@@ -1,3 +1,4 @@
 from .get_call_recordings import get_call_recordings
+from .list_webhooks import list_webhooks
 
-__all__ = ["get_call_recordings"]
+__all__ = ["get_call_recordings", "list_webhooks"]

--- a/openphone_sdk/list_webhooks.py
+++ b/openphone_sdk/list_webhooks.py
@@ -1,0 +1,12 @@
+from openphone_sdk.request import client
+from openphone_client.api.webhooks.list_webhooks_v_1 import sync
+from openphone_client.models.list_webhooks_v1_response_200 import ListWebhooksV1Response200
+from openphone_client.types import UNSET
+
+
+def list_webhooks(user_id: str | None = None) -> ListWebhooksV1Response200:
+    """Return webhooks for the authenticated workspace or raise RuntimeError on non-200."""
+    res = sync(client=client(), user_id=user_id if user_id is not None else UNSET)
+    if isinstance(res, ListWebhooksV1Response200):
+        return res
+    raise RuntimeError(f"Unexpected response {type(res).__name__}")

--- a/openphone_sdk/request.py
+++ b/openphone_sdk/request.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import os
 from typing import Final
 
-from openphone_client import Client, AsyncClient   # <-- import AsyncClient
+from openphone_client import Client
 
 BASE: Final[str] = os.getenv("OPENPHONE_BASE_URL", "https://api.openphone.com")
 
 _sync: Client | None = None
-_async: AsyncClient | None = None
+_async: Client | None = None
 
 
 def _get_key() -> str:
@@ -24,14 +24,14 @@ def _get_key() -> str:
 def _sync_client() -> Client:
     global _sync
     if _sync is None:
-        _sync = Client(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _sync = Client(base_url=BASE, headers={"X-API-KEY": _get_key()})
     return _sync
 
 
-def _async_client() -> AsyncClient:
+def _async_client() -> Client:
     global _async
     if _async is None:
-        _async = AsyncClient(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _async = Client(base_url=BASE, headers={"X-API-KEY": _get_key()})
     return _async
 
 
@@ -43,6 +43,6 @@ def client() -> Client:
     return _sync_client()
 
 
-def aclient() -> AsyncClient:
+def aclient() -> Client:
     """Shared asynchronous client (for upcoming async wrappers)."""
     return _async_client()

--- a/tests/test_list_webhooks.py
+++ b/tests/test_list_webhooks.py
@@ -1,0 +1,23 @@
+import os
+from httpx import Response
+
+
+def test_list_webhooks(httpx_mock):
+    os.environ["OPENPHONE_API_KEY"] = "k"
+    os.environ["OPENPHONE_BASE_URL"] = "https://api.openphone.com"
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.openphone.com/v1/webhooks",
+        json={"data": []},
+        status_code=200,
+    )
+
+    from openphone_sdk.list_webhooks import list_webhooks
+
+    out = list_webhooks()
+
+    req = httpx_mock.get_request()
+    assert req.method == "GET"
+    assert str(req.url) == "https://api.openphone.com/v1/webhooks"
+    assert req.headers.get("X-API-KEY") == "k"
+    assert out.data == []

--- a/todo.md
+++ b/todo.md
@@ -20,4 +20,4 @@
 - [ ] 19. wrap `/webhooks/create-message-webhook` → `openphone_sdk/create_message_webhook.py`
 - [ ] 20. wrap `/webhooks/delete-webhook-by-id` → `openphone_sdk/delete_webhook_by_id.py`
 - [ ] 21. wrap `/webhooks/get-webhook-by-id` → `openphone_sdk/get_webhook_by_id.py`
-- [ ] 22. wrap `/webhooks/list-webhooks` → `openphone_sdk/list_webhooks.py`
+- [x] 22. wrap `/webhooks/list-webhooks` → `openphone_sdk/list_webhooks.py`


### PR DESCRIPTION
## Summary
- add wrapper for `/webhooks/list-webhooks`
- export wrapper in package init
- fix request client initialization
- test list_webhooks wrapper
- mark TODO item complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685096bbb3f483268fd379dfdfcd7fcc