### PR TITLE
Add list conversations wrapper

### DIFF
--- a/openphone_sdk/__init__.py
+++ b/openphone_sdk/__init__.py
@@ -1,3 +1,4 @@
 from .get_call_recordings import get_call_recordings
+from .list_conversations import list_conversations
 
-__all__ = ["get_call_recordings"]
+__all__ = ["get_call_recordings", "list_conversations"]

--- a/openphone_sdk/list_conversations.py
+++ b/openphone_sdk/list_conversations.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import datetime
+from typing import List, Optional
+
+from openphone_sdk.request import client
+from openphone_client.api.conversations.list_conversations_v_1 import sync
+from openphone_client.models.list_conversations_v1_response_200 import ListConversationsV1Response200
+from openphone_client.types import UNSET
+
+
+def list_conversations(
+    *,
+    phone_number: Optional[str] = None,
+    phone_numbers: Optional[List[str]] = None,
+    user_id: Optional[str] = None,
+    created_after: Optional[datetime.datetime] = None,
+    created_before: Optional[datetime.datetime] = None,
+    exclude_inactive: Optional[bool] = None,
+    updated_after: Optional[datetime.datetime] = None,
+    updated_before: Optional[datetime.datetime] = None,
+    max_results: int = 10,
+    page_token: Optional[str] = None,
+) -> ListConversationsV1Response200:
+    """Return conversations or raise RuntimeError on non-200."""
+    res = sync(
+        client=client(),
+        phone_number=phone_number if phone_number is not None else UNSET,
+        phone_numbers=phone_numbers if phone_numbers is not None else UNSET,
+        user_id=user_id if user_id is not None else UNSET,
+        created_after=created_after if created_after is not None else UNSET,
+        created_before=created_before if created_before is not None else UNSET,
+        exclude_inactive=exclude_inactive if exclude_inactive is not None else UNSET,
+        updated_after=updated_after if updated_after is not None else UNSET,
+        updated_before=updated_before if updated_before is not None else UNSET,
+        max_results=max_results,
+        page_token=page_token if page_token is not None else UNSET,
+    )
+    if isinstance(res, ListConversationsV1Response200):
+        return res
+    raise RuntimeError(f"Unexpected response {type(res).__name__}")

--- a/openphone_sdk/request.py
+++ b/openphone_sdk/request.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import os
 from typing import Final
 
-from openphone_client import Client, AsyncClient   # <-- import AsyncClient
+from openphone_client import Client
 
 BASE: Final[str] = os.getenv("OPENPHONE_BASE_URL", "https://api.openphone.com")
 
 _sync: Client | None = None
-_async: AsyncClient | None = None
+_async: Client | None = None
 
 
 def _get_key() -> str:
@@ -24,14 +24,14 @@ def _get_key() -> str:
 def _sync_client() -> Client:
     global _sync
     if _sync is None:
-        _sync = Client(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _sync = Client(base_url=BASE, headers={"X-API-KEY": _get_key()})
     return _sync
 
 
-def _async_client() -> AsyncClient:
+def _async_client() -> Client:
     global _async
     if _async is None:
-        _async = AsyncClient(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _async = Client(base_url=BASE, headers={"X-API-KEY": _get_key()})
     return _async
 
 
@@ -43,6 +43,6 @@ def client() -> Client:
     return _sync_client()
 
 
-def aclient() -> AsyncClient:
+def aclient() -> Client:
     """Shared asynchronous client (for upcoming async wrappers)."""
     return _async_client()

--- a/tests/test_list_conversations.py
+++ b/tests/test_list_conversations.py
@@ -1,0 +1,23 @@
+import os
+from httpx import Response
+
+
+def test_list_conversations(httpx_mock):
+    os.environ["OPENPHONE_API_KEY"] = "k"
+    os.environ["OPENPHONE_BASE_URL"] = "https://api.openphone.com"
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.openphone.com/v1/conversations?maxResults=10",
+        json={"data": [], "totalItems": 0, "nextPageToken": None},
+        status_code=200,
+    )
+
+    from openphone_sdk.list_conversations import list_conversations
+
+    out = list_conversations()
+
+    req = httpx_mock.get_request()
+    assert req.method == "GET"
+    assert str(req.url) == "https://api.openphone.com/v1/conversations?maxResults=10"
+    assert req.headers.get("X-API-KEY") == "k"
+    assert out.data == []

--- a/todo.md
+++ b/todo.md
@@ -9,7 +9,7 @@
 - [ ] 8. wrap `/contacts/get-contact-by-id` → `openphone_sdk/get_contact_by_id.py`
 - [ ] 9. wrap `/contacts/list-contacts` → `openphone_sdk/list_contacts.py`
 - [ ] 10. wrap `/contacts/update-contact-by-id` → `openphone_sdk/update_contact_by_id.py`
-- [ ] 11. wrap `/conversations/list-conversations` → `openphone_sdk/list_conversations.py`
+- [x] 11. wrap `/conversations/list-conversations` → `openphone_sdk/list_conversations.py`
 - [ ] 12. wrap `/messages/get-message-by-id` → `openphone_sdk/get_message_by_id.py`
 - [ ] 13. wrap `/messages/list-messages` → `openphone_sdk/list_messages.py`
 - [ ] 14. wrap `/messages/send-message` → `openphone_sdk/send_message.py`


### PR DESCRIPTION
## Summary
- wrap `/conversations/list-conversations`
- expose `list_conversations` in SDK
- test listing conversations
- fix request helper
- mark todo item as done

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685096e63f9c8326bf2a624b2570f2ae