### PR TITLE
Implement get_call_transcript wrapper

### DIFF
--- a/openphone_sdk/__init__.py
+++ b/openphone_sdk/__init__.py
@@ -1,3 +1,4 @@
 from .get_call_recordings import get_call_recordings
+from .get_call_transcript import get_call_transcript
 
-__all__ = ["get_call_recordings"]
+__all__ = ["get_call_recordings", "get_call_transcript"]

--- a/openphone_sdk/get_call_transcript.py
+++ b/openphone_sdk/get_call_transcript.py
@@ -1,0 +1,13 @@
+from openphone_sdk.request import client
+from openphone_client.api.calls.get_call_transcript_v_1 import sync
+from openphone_client.models.get_call_transcript_v1_response_200 import (
+    GetCallTranscriptV1Response200,
+)
+
+
+def get_call_transcript(call_id: str) -> GetCallTranscriptV1Response200:
+    """Return transcript for the given call ID or raise RuntimeError on non-200."""
+    res = sync(id=call_id, client=client())
+    if isinstance(res, GetCallTranscriptV1Response200):
+        return res
+    raise RuntimeError(f"Unexpected response {type(res).__name__}")

--- a/openphone_sdk/request.py
+++ b/openphone_sdk/request.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import os
 from typing import Final
 
-from openphone_client import Client, AsyncClient   # <-- import AsyncClient
+from openphone_client import Client
 
 BASE: Final[str] = os.getenv("OPENPHONE_BASE_URL", "https://api.openphone.com")
 
 _sync: Client | None = None
-_async: AsyncClient | None = None
+_async: Client | None = None
 
 
 def _get_key() -> str:
@@ -24,14 +24,14 @@ def _get_key() -> str:
 def _sync_client() -> Client:
     global _sync
     if _sync is None:
-        _sync = Client(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _sync = Client(base_url=BASE, headers={"X-API-KEY": _get_key()})
     return _sync
 
 
-def _async_client() -> AsyncClient:
+def _async_client() -> Client:
     global _async
     if _async is None:
-        _async = AsyncClient(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _async = Client(base_url=BASE, headers={"X-API-KEY": _get_key()})
     return _async
 
 
@@ -43,6 +43,6 @@ def client() -> Client:
     return _sync_client()
 
 
-def aclient() -> AsyncClient:
+def aclient() -> Client:
     """Shared asynchronous client (for upcoming async wrappers)."""
     return _async_client()

--- a/tests/test_get_call_transcript.py
+++ b/tests/test_get_call_transcript.py
@@ -1,0 +1,32 @@
+import os
+from httpx import Response
+
+
+def test_get_call_transcript(httpx_mock):
+    os.environ["OPENPHONE_API_KEY"] = "k"
+    os.environ["OPENPHONE_BASE_URL"] = "https://api.openphone.com"
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.openphone.com/v1/call-transcripts/AC123",
+        json={
+            "data": {
+                "callId": "AC123",
+                "createdAt": "2023-01-01T00:00:00Z",
+                "dialogue": None,
+                "duration": 1.0,
+                "status": "completed",
+            }
+        },
+        status_code=200,
+    )
+
+    from openphone_sdk.get_call_transcript import get_call_transcript
+
+    out = get_call_transcript("AC123")
+
+    req = httpx_mock.get_request()
+    assert req.method == "GET"
+    assert str(req.url) == "https://api.openphone.com/v1/call-transcripts/AC123"
+    assert req.headers.get("X-API-KEY") == "k"
+    assert out.data.call_id == "AC123"
+    assert out.data.status.value == "completed"

--- a/todo.md
+++ b/todo.md
@@ -1,7 +1,7 @@
 # Wrapper backlog
 - [x] 1. wrap `/calls/get-call-recordings` → `openphone_sdk/get_call_recordings.py`
 - [ ] 2. wrap `/calls/get-call-summary` → `openphone_sdk/get_call_summary.py`
-- [ ] 3. wrap `/calls/get-call-transcript` → `openphone_sdk/get_call_transcript.py`
+- [x] 3. wrap `/calls/get-call-transcript` → `openphone_sdk/get_call_transcript.py`
 - [ ] 4. wrap `/calls/list-calls` → `openphone_sdk/list_calls.py`
 - [ ] 5. wrap `/contact-custom-fields/get-contact-custom-fields` → `openphone_sdk/get_contact_custom_fields.py`
 - [ ] 6. wrap `/contacts/create-contact` → `openphone_sdk/create_contact.py`


### PR DESCRIPTION
## Summary
- add wrapper for call transcript retrieval
- expose new wrapper in package exports
- adjust request helper for correct base URL and remove AsyncClient dependency
- test the get_call_transcript wrapper
- mark TODO as done

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509724bf908326bced12bf7ebcb320