### PR TITLE
Add send_message wrapper

### DIFF
--- a/openphone_sdk/__init__.py
+++ b/openphone_sdk/__init__.py
@@ -1,3 +1,4 @@
 from .get_call_recordings import get_call_recordings
+from .send_message import send_message
 
-__all__ = ["get_call_recordings"]
+__all__ = ["get_call_recordings", "send_message"]

--- a/openphone_sdk/request.py
+++ b/openphone_sdk/request.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import os
 from typing import Final
 
-from openphone_client import Client, AsyncClient   # <-- import AsyncClient
+from openphone_client import AuthenticatedClient
 
 BASE: Final[str] = os.getenv("OPENPHONE_BASE_URL", "https://api.openphone.com")
 
-_sync: Client | None = None
-_async: AsyncClient | None = None
+_sync: AuthenticatedClient | None = None
+_async: AuthenticatedClient | None = None
 
 
 def _get_key() -> str:
@@ -21,28 +21,32 @@ def _get_key() -> str:
     return key
 
 
-def _sync_client() -> Client:
+def _sync_client() -> AuthenticatedClient:
     global _sync
     if _sync is None:
-        _sync = Client(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _sync = AuthenticatedClient(
+            base_url=BASE, headers={"X-API-KEY": _get_key()}, token=""
+        )
     return _sync
 
 
-def _async_client() -> AsyncClient:
+def _async_client() -> AuthenticatedClient:
     global _async
     if _async is None:
-        _async = AsyncClient(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _async = AuthenticatedClient(
+            base_url=BASE, headers={"X-API-KEY": _get_key()}, token=""
+        )
     return _async
 
 
 # Public helpers -------------------------------------------------------------
 
 
-def client() -> Client:
+def client() -> AuthenticatedClient:
     """Shared synchronous client."""
     return _sync_client()
 
 
-def aclient() -> AsyncClient:
+def aclient() -> AuthenticatedClient:
     """Shared asynchronous client (for upcoming async wrappers)."""
     return _async_client()

--- a/openphone_sdk/send_message.py
+++ b/openphone_sdk/send_message.py
@@ -1,0 +1,12 @@
+from openphone_sdk.request import client
+from openphone_client.api.messages.send_message_v_1 import sync
+from openphone_client.models.send_message_v1_body import SendMessageV1Body
+from openphone_client.models.send_message_v1_response_202 import SendMessageV1Response202
+
+
+def send_message(body: SendMessageV1Body) -> SendMessageV1Response202:
+    """Send a text message and return the response or raise RuntimeError."""
+    res = sync(client=client(), body=body)
+    if isinstance(res, SendMessageV1Response202):
+        return res
+    raise RuntimeError(f"Unexpected response {type(res).__name__}")

--- a/tests/test_send_message.py
+++ b/tests/test_send_message.py
@@ -1,0 +1,42 @@
+import os
+from httpx import Response
+
+from openphone_client.models.send_message_v1_body import SendMessageV1Body
+
+
+def test_send_message(httpx_mock):
+    os.environ["OPENPHONE_API_KEY"] = "k"
+    os.environ["OPENPHONE_BASE_URL"] = "https://api.openphone.com"
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openphone.com/v1/messages",
+        json={
+            "data": {
+                "id": "msg1",
+                "to": ["+123"],
+                "from": "+1555",
+                "text": "hi",
+                "phoneNumberId": None,
+                "direction": "outgoing",
+                "userId": "u1",
+                "status": "queued",
+                "createdAt": "2023-01-01T00:00:00Z",
+                "updatedAt": "2023-01-01T00:00:00Z",
+            }
+        },
+        status_code=202,
+    )
+
+    from openphone_sdk.send_message import send_message
+
+    body = SendMessageV1Body(content="hi", from_="+1555", to=["+123"])
+    out = send_message(body)
+
+    req = httpx_mock.get_request()
+    assert req.method == "POST"
+    assert str(req.url) == "https://api.openphone.com/v1/messages"
+    assert req.headers.get("X-API-KEY") == "k"
+    import json
+
+    assert json.loads(req.content.decode()) == body.to_dict()
+    assert out.data.id == "msg1"

--- a/todo.md
+++ b/todo.md
@@ -12,7 +12,7 @@
 - [ ] 11. wrap `/conversations/list-conversations` → `openphone_sdk/list_conversations.py`
 - [ ] 12. wrap `/messages/get-message-by-id` → `openphone_sdk/get_message_by_id.py`
 - [ ] 13. wrap `/messages/list-messages` → `openphone_sdk/list_messages.py`
-- [ ] 14. wrap `/messages/send-message` → `openphone_sdk/send_message.py`
+- [x] 14. wrap `/messages/send-message` → `openphone_sdk/send_message.py`
 - [ ] 15. wrap `/phone-numbers/list-phone-numbers` → `openphone_sdk/list_phone_numbers.py`
 - [ ] 16. wrap `/webhooks/create-call-summary-webhook` → `openphone_sdk/create_call_summary_webhook.py`
 - [ ] 17. wrap `/webhooks/create-call-transcript-webhook` → `openphone_sdk/create_call_transcript_webhook.py`


### PR DESCRIPTION
## Summary
- provide wrapper for `send_message`
- expose it in package exports
- support AuthenticatedClient in request helper
- test sending messages
- mark todo item complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685097648610832686034078b9bf55b2