### PR TITLE
Add list_messages wrapper

### DIFF
--- a/openphone_sdk/__init__.py
+++ b/openphone_sdk/__init__.py
@@ -1,3 +1,4 @@
 from .get_call_recordings import get_call_recordings
+from .list_messages import list_messages
 
-__all__ = ["get_call_recordings"]
+__all__ = ["get_call_recordings", "list_messages"]

--- a/openphone_sdk/list_messages.py
+++ b/openphone_sdk/list_messages.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Union
+
+from openphone_sdk.request import client
+from openphone_client.api.messages.list_messages_v_1 import sync
+from openphone_client.models.list_messages_v1_response_200 import ListMessagesV1Response200
+from openphone_client.types import UNSET, Unset
+
+
+def list_messages(
+    phone_number_id: str,
+    participants: list[str],
+    *,
+    user_id: Union[Unset, str] = UNSET,
+    since: Union[Unset, datetime] = UNSET,
+    created_after: Union[Unset, datetime] = UNSET,
+    created_before: Union[Unset, datetime] = UNSET,
+    max_results: int = 10,
+    page_token: Union[Unset, str] = UNSET,
+) -> ListMessagesV1Response200:
+    """Return messages matching filters or raise RuntimeError on non-200."""
+    res = sync(
+        client=client(),
+        phone_number_id=phone_number_id,
+        user_id=user_id,
+        participants=participants,
+        since=since,
+        created_after=created_after,
+        created_before=created_before,
+        max_results=max_results,
+        page_token=page_token,
+    )
+    if isinstance(res, ListMessagesV1Response200):
+        return res
+    raise RuntimeError(f"Unexpected response {type(res).__name__}")

--- a/openphone_sdk/request.py
+++ b/openphone_sdk/request.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 import os
 from typing import Final
 
-from openphone_client import Client, AsyncClient   # <-- import AsyncClient
+from openphone_client import Client
+
+# NOTE: generated client exposes async helpers on ``Client`` itself, so
+# alias ``AsyncClient`` for upcoming wrappers expecting this name.
+AsyncClient = Client
 
 BASE: Final[str] = os.getenv("OPENPHONE_BASE_URL", "https://api.openphone.com")
 
@@ -24,14 +28,14 @@ def _get_key() -> str:
 def _sync_client() -> Client:
     global _sync
     if _sync is None:
-        _sync = Client(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _sync = Client(base_url=BASE, headers={"X-API-KEY": _get_key()})
     return _sync
 
 
 def _async_client() -> AsyncClient:
     global _async
     if _async is None:
-        _async = AsyncClient(base_url=f"{BASE}/v1", headers={"X-API-KEY": _get_key()})
+        _async = AsyncClient(base_url=BASE, headers={"X-API-KEY": _get_key()})
     return _async
 
 

--- a/tests/test_list_messages.py
+++ b/tests/test_list_messages.py
@@ -1,0 +1,27 @@
+import os
+import re
+
+
+def test_list_messages(httpx_mock):
+    os.environ["OPENPHONE_API_KEY"] = "k"
+    os.environ["OPENPHONE_BASE_URL"] = "https://api.openphone.com"
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(r"https://api\.openphone\.com/v1/messages.*"),
+        json={"data": [], "totalItems": 0, "nextPageToken": None},
+        status_code=200,
+    )
+
+    from openphone_sdk.list_messages import list_messages
+
+    out = list_messages("PN1", participants=["+1555"], max_results=5)
+
+    req = httpx_mock.get_request()
+    assert req.method == "GET"
+    assert str(req.url).startswith("https://api.openphone.com/v1/messages")
+    assert req.headers.get("X-API-KEY") == "k"
+    params = req.url.params
+    assert params["phoneNumberId"] == "PN1"
+    assert params.get_list("participants") == ["+1555"]
+    assert params["maxResults"] == "5"
+    assert out.data == []

--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,7 @@
 - [ ] 10. wrap `/contacts/update-contact-by-id` → `openphone_sdk/update_contact_by_id.py`
 - [ ] 11. wrap `/conversations/list-conversations` → `openphone_sdk/list_conversations.py`
 - [ ] 12. wrap `/messages/get-message-by-id` → `openphone_sdk/get_message_by_id.py`
-- [ ] 13. wrap `/messages/list-messages` → `openphone_sdk/list_messages.py`
+ - [x] 13. wrap `/messages/list-messages` → `openphone_sdk/list_messages.py`
 - [ ] 14. wrap `/messages/send-message` → `openphone_sdk/send_message.py`
 - [ ] 15. wrap `/phone-numbers/list-phone-numbers` → `openphone_sdk/list_phone_numbers.py`
 - [ ] 16. wrap `/webhooks/create-call-summary-webhook` → `openphone_sdk/create_call_summary_webhook.py`


### PR DESCRIPTION
## Summary
- implement `list_messages` wrapper
- fix `request` helper to alias `AsyncClient` and adjust base URL
- expose wrapper in SDK
- test `list_messages`
- mark task complete in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509812934c8326ba85a219c145a164